### PR TITLE
Wasi nn/external delegate support2

### DIFF
--- a/build-scripts/runtime_lib.cmake
+++ b/build-scripts/runtime_lib.cmake
@@ -96,19 +96,6 @@ if (WAMR_BUILD_LIB_PTHREAD_SEMAPHORE EQUAL 1)
 endif ()
 
 if (WAMR_BUILD_WASI_NN EQUAL 1)
-    if (NOT EXISTS "${WAMR_ROOT_DIR}/core/deps/tensorflow-src")
-        execute_process(COMMAND ${WAMR_ROOT_DIR}/core/deps/install_tensorflow.sh
-                        RESULT_VARIABLE TENSORFLOW_RESULT
-        )
-    else ()
-        message("Tensorflow is already downloaded.")
-    endif()
-    set(TENSORFLOW_SOURCE_DIR "${WAMR_ROOT_DIR}/core/deps/tensorflow-src")
-    include_directories (${CMAKE_CURRENT_BINARY_DIR}/flatbuffers/include)
-    include_directories (${TENSORFLOW_SOURCE_DIR})
-    add_subdirectory(
-        "${TENSORFLOW_SOURCE_DIR}/tensorflow/lite"
-        "${CMAKE_CURRENT_BINARY_DIR}/tensorflow-lite" EXCLUDE_FROM_ALL)
     include (${IWASM_DIR}/libraries/wasi-nn/wasi_nn.cmake)
 endif ()
 

--- a/core/iwasm/libraries/wasi-nn/src/wasi_nn_tensorflowlite.cpp
+++ b/core/iwasm/libraries/wasi-nn/src/wasi_nn_tensorflowlite.cpp
@@ -18,7 +18,7 @@
 #include <tensorflow/lite/error_reporter.h>
 #include <tensorflow/lite/delegates/gpu/delegate.h>
 
-#ifdef TFLITE_DELEGATES_EXTERNAL
+#ifdef _TFLITE_ENABLE_EXTERNAL_DELEGATE
 #include <tensorflow/lite/delegates/external/external_delegate.h>
 #endif
 /* Global variables */
@@ -88,16 +88,15 @@ tensorflowlite_load(graph_builder_array *builder, graph_encoding encoding,
         case gpu:
         {
 #ifdef _TFLITE_ENABLE_EXTERNAL_DELEGATE            
-            TfLiteExternalDelegateOptions options;
-            // https://www.tensorflow.org/lite/performance/gpu
-            options = TfLiteExternalDelegateOptionsDefault ("/usr/lib/libvx_delegate.so");
+            auto options = TfLiteExternalDelegateOptionsDefault ("/usr/lib/libvx_delegate.so");
 
             auto *delegate = TfLiteExternalDelegateCreate(&options);
             if (interpreter->ModifyGraphWithDelegate(delegate) != kTfLiteOk) {
-                NN_ERR_PRINTF("Error when enabling GPU delegate.");
+                NN_ERR_PRINTF("Error when enabling External delegate.");
                 use_default = true;
             }            
-#elseif _TFLITE_ENABLE_GPU
+#endif
+#ifdef _TFLITE_ENABLE_GPU
             // https://www.tensorflow.org/lite/performance/gpu
             auto options = TfLiteGpuDelegateOptionsV2Default();
             options.inference_preference =
@@ -110,7 +109,7 @@ tensorflowlite_load(graph_builder_array *builder, graph_encoding encoding,
                 NN_ERR_PRINTF("Error when enabling GPU delegate.");
                 use_default = true;
             } 
-#else                       
+                 
 #endif              
 
             break;

--- a/core/iwasm/libraries/wasi-nn/test/CMakeLists.txt
+++ b/core/iwasm/libraries/wasi-nn/test/CMakeLists.txt
@@ -167,7 +167,7 @@ add_executable (iwasm ${WAMR_ROOT_DIR}/product-mini/platforms/${WAMR_BUILD_PLATF
 
 install (TARGETS iwasm DESTINATION bin)
 
-target_link_libraries (iwasm vmlib ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} ${TENSORFLOW_LIB} -lm -ldl -lpthread)
+target_link_libraries (iwasm vmlib ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} ${NN_STATIC_LIB} -lm -ldl -lpthread)
 
 add_library (libiwasm SHARED ${WAMR_RUNTIME_LIB_SOURCE})
 

--- a/core/iwasm/libraries/wasi-nn/wasi_nn.cmake
+++ b/core/iwasm/libraries/wasi-nn/wasi_nn.cmake
@@ -47,6 +47,5 @@ set (
 )
 
 
-set (NN_SHARED_LIB tensorflow-lite stdc++ pthread m -ldl rt)
-set (NN_STATIC_LIB tensorflow-lite stdc++ pthread m -ldl rt)
+set (NN_LIBS tensorflow-lite stdc++ pthread m -ldl rt)
 

--- a/core/iwasm/libraries/wasi-nn/wasi_nn.cmake
+++ b/core/iwasm/libraries/wasi-nn/wasi_nn.cmake
@@ -7,7 +7,11 @@ add_definitions (-DWASM_ENABLE_WASI_NN=1)
 
 
 #find_package(tensorflow-lite REQUIRED)
-find_library(tensorflow-lite NAMES libtensorflow-lite.so)
+
+find_library(tensorflow-lite NAMES libtensorflow-lite.so 
+ PATHS ${CMAKE_SYSROOT}
+ PATH_SUFFIXES /usr/lib)
+
 if("${tensorflow-lite}" STREQUAL "tensorflow-lite-NOTFOUND")
     if (NOT EXISTS "${WAMR_ROOT_DIR}/core/deps/tensorflow-src")
         execute_process(COMMAND ${WAMR_ROOT_DIR}/core/deps/install_tensorflow.sh
@@ -24,11 +28,11 @@ if("${tensorflow-lite}" STREQUAL "tensorflow-lite-NOTFOUND")
         "${CMAKE_CURRENT_BINARY_DIR}/tensorflow-lite" EXCLUDE_FROM_ALL)      
 endif()
 
-if(TFLITE_ENABLE_EXTERNAL_DELEGATE)
-add_compile_definitions(-D_TFLITE_ENABLE_EXTERNAL_DELEGATE)
+if(TFLITE_ENABLE_EXTERNAL_DELEGATE EQUAL ON)
+add_definitions(-D_TFLITE_ENABLE_EXTERNAL_DELEGATE)
 endif()
-if(TFLITE_ENABLE_GPU)
-add_compile_definitions(-D_TFLITE_ENABLE_GPU)
+if(TFLITE_ENABLE_GPU EQUAL ON)
+add_definitions(-D_TFLITE_ENABLE_GPU)
 endif()
 
 include_directories (${WASI_NN_DIR})

--- a/core/iwasm/libraries/wasi-nn/wasi_nn.cmake
+++ b/core/iwasm/libraries/wasi-nn/wasi_nn.cmake
@@ -46,10 +46,7 @@ set (
     ${WASI_NN_DIR}/src/utils/wasi_nn_app_native.c
 )
 
-if(TFLITE_BUILD_SHARED_LIB EQUAL ON)
-set (NN_STATIC_LIB)
+
 set (NN_SHARED_LIB tensorflow-lite stdc++ pthread m -ldl rt)
-else()
 set (NN_STATIC_LIB tensorflow-lite stdc++ pthread m -ldl rt)
-set (NN_SHARED_LIB)
-endif()
+

--- a/product-mini/platforms/linux/CMakeLists.txt
+++ b/product-mini/platforms/linux/CMakeLists.txt
@@ -171,7 +171,8 @@ set_target_properties (iwasm PROPERTIES POSITION_INDEPENDENT_CODE ON)
 
 install (TARGETS iwasm DESTINATION bin)
 
-target_link_libraries (iwasm vmlib ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} -lm -ldl -lpthread)
+
+target_link_libraries (iwasm vmlib ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} ${NN_STATIC_LIB})
 
 add_library (libiwasm SHARED ${WAMR_RUNTIME_LIB_SOURCE})
 
@@ -179,4 +180,4 @@ install (TARGETS libiwasm DESTINATION lib)
 
 set_target_properties (libiwasm PROPERTIES OUTPUT_NAME iwasm)
 
-target_link_libraries (libiwasm ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} -lm -ldl -lpthread)
+target_link_libraries (libiwasm ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} ${NN_SHARED_LIB})

--- a/product-mini/platforms/linux/CMakeLists.txt
+++ b/product-mini/platforms/linux/CMakeLists.txt
@@ -172,7 +172,7 @@ set_target_properties (iwasm PROPERTIES POSITION_INDEPENDENT_CODE ON)
 install (TARGETS iwasm DESTINATION bin)
 
 
-target_link_libraries (iwasm vmlib ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} ${NN_STATIC_LIB})
+target_link_libraries (iwasm vmlib ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} ${NN_LIBS})
 
 add_library (libiwasm SHARED ${WAMR_RUNTIME_LIB_SOURCE})
 
@@ -180,4 +180,4 @@ install (TARGETS libiwasm DESTINATION lib)
 
 set_target_properties (libiwasm PROPERTIES OUTPUT_NAME iwasm)
 
-target_link_libraries (libiwasm ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} ${NN_SHARED_LIB})
+target_link_libraries (libiwasm ${LLVM_AVAILABLE_LIBS} ${UV_A_LIBS} ${NN_LIBS})


### PR DESCRIPTION
Libraries such as Tensorflow-lite have already been built and installed using a different build system, so I would like to first find_library (or find_package) if it is not installed before downloading.