### PR TITLE
fix: remove calls to save_resized_tensor_as_jpeg

### DIFF
--- a/core/iwasm/libraries/wasi-nn/src/wasi_nn_tensorflowlite.cpp
+++ b/core/iwasm/libraries/wasi-nn/src/wasi_nn_tensorflowlite.cpp
@@ -170,7 +170,6 @@ preprocess_and_resize_tensor(TfLiteTensor *input_tensor_tf,
         case fp32:
         {
             cv::Mat input_mat(img_h, img_w, CV_32FC3, input_tensor->data);
-            save_resized_tensor_as_jpeg(input_mat, filename_org);
             cv::resize(input_mat, resized_mat, cv::Size(tf_w, tf_h));
             break;
         }
@@ -178,11 +177,9 @@ preprocess_and_resize_tensor(TfLiteTensor *input_tensor_tf,
         {
             if (img_c == 1) {
                 cv::Mat input_mat(img_h, img_w, CV_8UC1, input_tensor->data);
-                save_resized_tensor_as_jpeg(input_mat, filename_org);
                 cv::resize(input_mat, resized_mat, cv::Size(tf_w, tf_h));
             } else if (img_c == 3) {
                 cv::Mat input_mat(img_h, img_w, CV_8UC3, input_tensor->data);
-                save_resized_tensor_as_jpeg(input_mat, filename_org);
                 cv::resize(input_mat, resized_mat, cv::Size(tf_w, tf_h));
             }
             break;


### PR DESCRIPTION
This pull request makes a minor change to the preprocessing logic for image tensors in TensorFlow Lite. The main update is the removal of calls to `save_resized_tensor_as_jpeg`, which previously saved intermediate image data as JPEG files during preprocessing.

* Removed calls to `save_resized_tensor_as_jpeg` for both `fp32` and `up8` tensor types in the `preprocess_and_resize_tensor` function in `wasi_nn_tensorflowlite.cpp`, reducing unnecessary file I/O during preprocessing.